### PR TITLE
#6: implemented naming convention tests N3 & N4

### DIFF
--- a/src/test/java/com/devonfw/sample/archunit/NamingConventionTest.java
+++ b/src/test/java/com/devonfw/sample/archunit/NamingConventionTest.java
@@ -15,7 +15,6 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 @AnalyzeClasses(packages = "com.devonfw.sample.archunit", importOptions = ImportOption.DoNotIncludeTests.class)
 public class NamingConventionTest {
 
-
     /**
      * DevonNamingConventionCheck verifying that classes extending ApplicationPersistenceEntity are following the
      * naming convention by ending with 'Entity'.

--- a/src/test/java/com/devonfw/sample/archunit/NamingConventionTest.java
+++ b/src/test/java/com/devonfw/sample/archunit/NamingConventionTest.java
@@ -1,0 +1,42 @@
+package com.devonfw.sample.archunit;
+
+import com.devonfw.sample.archunit.general.common.AbstractEto;
+import com.devonfw.sample.archunit.general.dataaccess.ApplicationPersistenceEntity;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+/**
+ * JUnit test that validates the naming convention rules of this application.
+ */
+@AnalyzeClasses(packages = "com.devonfw.sample.archunit", importOptions = ImportOption.DoNotIncludeTests.class)
+public class NamingConventionTest {
+
+
+    /**
+     * DevonNamingConventionCheck verifying that classes extending ApplicationPersistenceEntity are following the
+     * naming convention by ending with 'Entity'.
+     */
+    @ArchTest
+    private static final ArchRule DevonNamingConventionEntityCheck =
+            classes()
+                    .that().areAssignableTo(ApplicationPersistenceEntity.class)
+                    .should().haveSimpleNameEndingWith("Entity")
+                    .because("Classes extending ApplicationPersistenceEntity must follow the naming convention by" +
+                            "ending with 'Entity'.");
+
+    /**
+     * DevonNamingConventionCheck verifying that classes extending AbstractEto are following the naming convention by
+     * ending with Eto.
+     */
+    @ArchTest
+    private static final ArchRule DevonNamingConventionEtoCheck =
+            classes()
+                    .that().areAssignableTo(AbstractEto.class)
+                    .should().haveSimpleNameEndingWith("Eto")
+                    .because("Classes extending AbstractEto must follow the naming convention by ending with 'Eto'.");
+
+}


### PR DESCRIPTION
Due to missing classes needed by naming convention rules N1, N2, and N5 to N8, the implementation of these rules has not been handled in this task.