### PR TITLE
#7: implemented security rule Y1

### DIFF
--- a/src/main/java/com/devonfw/sample/archunit/task/logic/UcDeleteTaskItem.java
+++ b/src/main/java/com/devonfw/sample/archunit/task/logic/UcDeleteTaskItem.java
@@ -1,10 +1,12 @@
 package com.devonfw.sample.archunit.task.logic;
 
+import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.transaction.Transactional;
 
+import com.devonfw.sample.archunit.task.common.security.ApplicationAccessControlConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +31,7 @@ public class UcDeleteTaskItem extends AbstractUc {
    * @param id the {@link com.devonfw.sample.archunit.task.dataaccess.TaskListEntity#getId() primary key} of the
    *        {@link com.devonfw.sample.archunit.task.dataaccess.TaskListEntity} to delete.
    */
-  // @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_DELETE_TASK_ITEM)
+  @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_DELETE_TASK_ITEM)
   public void delete(Long id) {
 
     this.taskItemRepository.deleteById(id);
@@ -38,7 +40,7 @@ public class UcDeleteTaskItem extends AbstractUc {
   /**
    * @param item the {@link TaskItemEto} to delete.
    */
-  // @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_DELETE_TASK_ITEM)
+  @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_DELETE_TASK_ITEM)
   public void delete(TaskItemEto item) {
 
     Long id = item.getId();

--- a/src/main/java/com/devonfw/sample/archunit/task/logic/UcDeleteTaskList.java
+++ b/src/main/java/com/devonfw/sample/archunit/task/logic/UcDeleteTaskList.java
@@ -1,10 +1,12 @@
 package com.devonfw.sample.archunit.task.logic;
 
+import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.transaction.Transactional;
 
+import com.devonfw.sample.archunit.task.common.security.ApplicationAccessControlConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +31,7 @@ public class UcDeleteTaskList extends AbstractUc {
    * @param id the {@link com.devonfw.sample.archunit.task.dataaccess.TaskListEntity#getId() primary key} of the
    *        {@link com.devonfw.sample.archunit.task.dataaccess.TaskListEntity} to delete.
    */
-  // @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_DELETE_TASK_ITEM)
+  @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_DELETE_TASK_ITEM)
   public void delete(Long id) {
 
     this.taskListRepository.deleteById(id);
@@ -38,7 +40,7 @@ public class UcDeleteTaskList extends AbstractUc {
   /**
    * @param list the {@link TaskListEto} to delete.
    */
-  // @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_DELETE_TASK_ITEM)
+   @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_DELETE_TASK_ITEM)
   public void delete(TaskListEto list) {
 
     Long id = list.getId();

--- a/src/main/java/com/devonfw/sample/archunit/task/logic/UcFindTaskItem.java
+++ b/src/main/java/com/devonfw/sample/archunit/task/logic/UcFindTaskItem.java
@@ -2,6 +2,7 @@ package com.devonfw.sample.archunit.task.logic;
 
 import java.util.Optional;
 
+import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -9,6 +10,7 @@ import javax.transaction.Transactional;
 
 import com.devonfw.sample.archunit.general.logic.AbstractUc;
 import com.devonfw.sample.archunit.task.common.TaskItemEto;
+import com.devonfw.sample.archunit.task.common.security.ApplicationAccessControlConfig;
 import com.devonfw.sample.archunit.task.dataaccess.TaskItemEntity;
 import com.devonfw.sample.archunit.task.dataaccess.TaskItemRepository;
 
@@ -31,7 +33,7 @@ public class UcFindTaskItem extends AbstractUc {
    * @return the {@link TaskItemEto} with the given {@link TaskItemEto#getId() primary key} or {@code null} if not
    *         found.
    */
-  // @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_FIND_TASK_ITEM)
+  @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_FIND_TASK_ITEM)
   public TaskItemEto findById(Long itemId) {
 
     Optional<TaskItemEntity> item = this.taskItemRepository.findById(itemId);

--- a/src/main/java/com/devonfw/sample/archunit/task/logic/UcFindTaskList.java
+++ b/src/main/java/com/devonfw/sample/archunit/task/logic/UcFindTaskList.java
@@ -2,6 +2,7 @@ package com.devonfw.sample.archunit.task.logic;
 
 import java.util.Optional;
 
+import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -10,6 +11,7 @@ import javax.transaction.Transactional;
 import com.devonfw.sample.archunit.general.logic.AbstractUc;
 import com.devonfw.sample.archunit.task.common.TaskListCto;
 import com.devonfw.sample.archunit.task.common.TaskListEto;
+import com.devonfw.sample.archunit.task.common.security.ApplicationAccessControlConfig;
 import com.devonfw.sample.archunit.task.dataaccess.TaskListEntity;
 import com.devonfw.sample.archunit.task.dataaccess.TaskListRepository;
 
@@ -34,7 +36,7 @@ public class UcFindTaskList extends AbstractUc {
    * @param listId the {@link TaskListEntity#getId() primary key} of the {@link TaskListEntity} to find.
    * @return the {@link TaskListEto} for the given {@link TaskListEto#getId() primary key} or {@code null} if not found.
    */
-  // @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_FIND_TASK_LIST)
+  @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_FIND_TASK_LIST)
   public TaskListEto findById(Long listId) {
 
     Optional<TaskListEntity> taskList = this.taskListRepository.findById(listId);
@@ -45,7 +47,7 @@ public class UcFindTaskList extends AbstractUc {
    * @param listId the {@link TaskListEntity#getId() primary key} of the {@link TaskListEntity} to find.
    * @return the {@link TaskListCto} for the given {@link TaskListEto#getId() primary key} or {@code null} if not found.
    */
-  // @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_FIND_TASK_LIST)
+  @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_FIND_TASK_LIST)
   public TaskListCto findCtoById(Long listId) {
 
     Optional<TaskListEntity> list = this.taskListRepository.findById(listId);

--- a/src/main/java/com/devonfw/sample/archunit/task/logic/UcSaveTaskItem.java
+++ b/src/main/java/com/devonfw/sample/archunit/task/logic/UcSaveTaskItem.java
@@ -1,5 +1,6 @@
 package com.devonfw.sample.archunit.task.logic;
 
+import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -7,6 +8,7 @@ import javax.transaction.Transactional;
 
 import com.devonfw.sample.archunit.general.logic.AbstractUc;
 import com.devonfw.sample.archunit.task.common.TaskItemEto;
+import com.devonfw.sample.archunit.task.common.security.ApplicationAccessControlConfig;
 import com.devonfw.sample.archunit.task.dataaccess.TaskItemEntity;
 import com.devonfw.sample.archunit.task.dataaccess.TaskItemRepository;
 
@@ -28,7 +30,7 @@ public class UcSaveTaskItem extends AbstractUc {
    * @param item the {@link TaskItemEto} to save.
    * @return the {@link TaskItemEntity#getId() primary key} of the saved {@link TaskItemEntity}.
    */
-  // @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_SAVE_TASK_ITEM)
+  @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_SAVE_TASK_ITEM)
   public Long save(TaskItemEto item) {
 
     TaskItemEntity entity = this.taskItemMapper.toEntity(item);

--- a/src/main/java/com/devonfw/sample/archunit/task/logic/UcSaveTaskList.java
+++ b/src/main/java/com/devonfw/sample/archunit/task/logic/UcSaveTaskList.java
@@ -1,5 +1,6 @@
 package com.devonfw.sample.archunit.task.logic;
 
+import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -7,6 +8,7 @@ import javax.transaction.Transactional;
 
 import com.devonfw.sample.archunit.general.logic.AbstractUc;
 import com.devonfw.sample.archunit.task.common.TaskListEto;
+import com.devonfw.sample.archunit.task.common.security.ApplicationAccessControlConfig;
 import com.devonfw.sample.archunit.task.dataaccess.TaskListEntity;
 import com.devonfw.sample.archunit.task.dataaccess.TaskListRepository;
 
@@ -28,7 +30,7 @@ public class UcSaveTaskList extends AbstractUc {
    * @param list the {@link TaskListEto} to save.
    * @return the {@link TaskListEntity#getId() primary key} of the saved {@link TaskListEntity}.
    */
-  // @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_SAVE_TASK_LIST)
+  @RolesAllowed(ApplicationAccessControlConfig.PERMISSION_SAVE_TASK_LIST)
   public Long save(TaskListEto list) {
 
     TaskListEntity entity = this.taskListMapper.toEntity(list);

--- a/src/test/java/com/devonfw/sample/archunit/SecurityTest.java
+++ b/src/test/java/com/devonfw/sample/archunit/SecurityTest.java
@@ -18,13 +18,13 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 public class SecurityTest {
 
     /**
-     * Checks 'UcImpl' classes for public methods.
+     * Checks 'Uc*Impl' classes for public methods.
      * Fails if a method is neither annotated with @PermitAll, @RolesAllowed nor @DenyAll.
      */
     @ArchTest
     private static final ArchRule shouldBeProperlyAnnotated = //
             methods()
-                    .that().areDeclaredInClassesThat().haveSimpleNameEndingWith("UcImpl")
+                    .that().areDeclaredInClassesThat().haveSimpleNameStartingWith("Uc")
                     .and().arePublic()
                     .should().beAnnotatedWith(PermitAll.class)
                     .orShould().beAnnotatedWith(RolesAllowed.class)

--- a/src/test/java/com/devonfw/sample/archunit/SecurityTest.java
+++ b/src/test/java/com/devonfw/sample/archunit/SecurityTest.java
@@ -1,0 +1,34 @@
+package com.devonfw.sample.archunit;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+/**
+ * JUnit test that validates the security rules of this application.
+ */
+@AnalyzeClasses(packages = "com.devonfw.sample.archunit", importOptions = ImportOption.DoNotIncludeTests.class)
+public class SecurityTest {
+
+    /**
+     * Checks 'UcImpl' classes for public methods.
+     * Fails if a method is neither annotated with @PermitAll, @RolesAllowed nor @DenyAll.
+     */
+    @ArchTest
+    private static final ArchRule shouldBeProperlyAnnotated = //
+            methods()
+                    .that().areDeclaredInClassesThat().haveSimpleNameEndingWith("UcImpl")
+                    .and().arePublic()
+                    .should().beAnnotatedWith(PermitAll.class)
+                    .orShould().beAnnotatedWith(RolesAllowed.class)
+                    .orShould().beAnnotatedWith(DenyAll.class)
+                    .because("All Use-Case implementation methods must be annotated with a security " +
+                            "constraint from javax.annotation.security");
+}


### PR DESCRIPTION
Closes #7: Since the override annotation cannot be checked by archunit after the code is compiled, 'UcImpl' classes are checked for public methods instead.