### PR TITLE
#28: Change Priotities of implemented Rules

### DIFF
--- a/src/test/java/com/devonfw/sample/archunit/AvoidCyclicDependenciesTest.java
+++ b/src/test/java/com/devonfw/sample/archunit/AvoidCyclicDependenciesTest.java
@@ -3,6 +3,8 @@ package com.devonfw.sample.archunit;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.CompositeArchRule;
+import com.tngtech.archunit.lang.Priority;
 
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
@@ -11,13 +13,13 @@ import com.tngtech.archunit.core.importer.ImportOption;
 @AnalyzeClasses(packages = "com.devonfw.sample.archunit", importOptions = ImportOption.DoNotIncludeTests.class)
 public class AvoidCyclicDependenciesTest {
     @ArchTest
-    static final ArchRule no_cyclic_dependencies_are_allowed =
-    slices()
-        .matching("..(*).(common|service|logic|dataaccess|batch|client)..")
-        .namingSlices("$1 slice")
-        .should()
-        .beFreeOfCycles()
-        //.ignoreDependency(alwaysTrue(), simpleNameEndingWith("Repository"))
-        .because("Cyclic dependencies should be prevented.");
+    static final ArchRule no_cyclic_dependencies_are_allowed = CompositeArchRule.priority(Priority.HIGH).of(
+            slices()
+                    .matching("..(*).(common|service|logic|dataaccess|batch|client)..")
+                    .namingSlices("$1 slice")
+                    .should()
+                    .beFreeOfCycles()
+                    // .ignoreDependency(alwaysTrue(), simpleNameEndingWith("Repository"))
+                    .because("Cyclic dependencies should be prevented."));
 
 }

--- a/src/test/java/com/devonfw/sample/archunit/ComponentRuleTest.java
+++ b/src/test/java/com/devonfw/sample/archunit/ComponentRuleTest.java
@@ -1,6 +1,7 @@
 package com.devonfw.sample.archunit;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.priority;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.Dependency;
@@ -11,6 +12,7 @@ import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.Priority;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 @AnalyzeClasses(packages = "com.devonfw.sample.archunit", importOptions = ImportOption.DoNotIncludeTests.class)
@@ -186,7 +188,7 @@ public class ComponentRuleTest {
    * verifying that the logic layer of a component may not depend on the dataaccess layer of another component.
    */
   @ArchTest
-  public static final ArchRule noComponentsLogicLayerDependsOnTheDataaccessLayerOfAnotherComponent = noClasses()
+  public static final ArchRule noComponentsLogicLayerDependsOnTheDataaccessLayerOfAnotherComponent = priority(Priority.HIGH).noClasses()
       .that(resideInLogicLayerOfAComponent).should(dependOnDiffComponentsDataaccessLayer)
       .as("Code from logic layer of a component shall not depend on dataaccess layer of a different component.")
       .allowEmptyShould(true);

--- a/src/test/java/com/devonfw/sample/archunit/PackageRuleTest.java
+++ b/src/test/java/com/devonfw/sample/archunit/PackageRuleTest.java
@@ -1,5 +1,5 @@
 package com.devonfw.sample.archunit;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.priority;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -11,6 +11,7 @@ import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.Priority;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 /**
@@ -58,7 +59,7 @@ public class PackageRuleTest {
 
   /* ArchRule and Condition */
   @ArchTest
-  public ArchRule shouldHaveValidLayers = classes().should(containsValidPackageStructureCondition());
+  public ArchRule shouldHaveValidLayers = priority(Priority.HIGH).classes().should(containsValidPackageStructureCondition());
 
   private static ArchCondition<JavaClass> containsValidPackageStructureCondition() {
 

--- a/src/test/java/com/devonfw/sample/archunit/ThirdPartyRulesTest.java
+++ b/src/test/java/com/devonfw/sample/archunit/ThirdPartyRulesTest.java
@@ -1,6 +1,7 @@
 package com.devonfw.sample.archunit;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.priority;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -14,6 +15,7 @@ import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.Priority;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 @AnalyzeClasses(packages = "com.devonfw.sample.archunit", importOptions = ImportOption.DoNotIncludeTests.class)
@@ -39,7 +41,7 @@ public class ThirdPartyRulesTest {
           + " which implements the javax.persistence.AttributeConverter instead of the 'javax.persistance.Convert' annotation");
 
   @ArchTest
-  public static ArchRule check_mysema_dependency = noClasses().should().dependOnClassesThat()
+  public static ArchRule check_mysema_dependency = priority(Priority.HIGH).noClasses().should().dependOnClassesThat()
       .resideInAPackage("com.mysema.query..")
       .because("Use official QueryDSL (com.querydsl.* e.g. from com.querydsl:querydsl-jpa).");
 
@@ -62,7 +64,8 @@ public class ThirdPartyRulesTest {
         String targetFullName = dependency.getTargetClass().getFullName();
         String targetClassDescription = dependency.getDescription();
         /*
-         * In case the project has a classic architecture using scopes, check that no API scoped class is using
+         * In case the project has a classic architecture using scopes, check that no
+         * API scoped class is using
          * 'javax.transaction.Transactional'
          */
         if (isApiScopedClassUsingTransactional(source, targetFullName) == true) {
@@ -204,8 +207,10 @@ public class ThirdPartyRulesTest {
             events.add(new SimpleConditionEvent(source, true, message));
           }
           /*
-           * In case the project has a classic architecture that uses scopes, check that Hibernate.Envers are only
-           * utilized inside the impl scope of the dataaccess layer. In addition, Hibernate internals also need to be
+           * In case the project has a classic architecture that uses scopes, check that
+           * Hibernate.Envers are only
+           * utilized inside the impl scope of the dataaccess layer. In addition,
+           * Hibernate internals also need to be
            * used inside the impl scope of the dataaccess layer.
            */
           if (isNotImplementingHibernateEnversInImplScope(source, targetClass) == true) {


### PR DESCRIPTION
Some rules in the old SonarQube plugin had different priorities than other rules. The most used priority was "CRITICAL". The default priority of ArchUnit is "MEDIUM". This way a mapping like this can be implemented:

HIGH=BLOCKER
MEDIUM=CRITICAL
LOW=MAJOR

LayerRules had the most variation of different priorities, but its currently not possible to simply add different priorities to the implementation of the LayerRules in ArchUnit.

#28