### PR TITLE
#4: implement package violations (#50)

### DIFF
--- a/src/main/java/com/devonfw/sample/archunit/violation/CaptialViolation/P3CapitalViolation.java
+++ b/src/main/java/com/devonfw/sample/archunit/violation/CaptialViolation/P3CapitalViolation.java
@@ -1,0 +1,5 @@
+package com.devonfw.sample.archunit.violation.CaptialViolation;
+
+public class P3CapitalViolation {
+    // No layer have capital letters in its name.
+}

--- a/src/main/java/com/devonfw/sample/archunit/violation/P1NoLayer.java
+++ b/src/main/java/com/devonfw/sample/archunit/violation/P1NoLayer.java
@@ -1,0 +1,5 @@
+package com.devonfw.sample.archunit.violation;
+
+public class P1NoLayer {
+    // no class should be without a Layer
+}

--- a/src/main/java/com/devonfw/sample/archunit/violation/violationlayer/P2ViolationLayer.java
+++ b/src/main/java/com/devonfw/sample/archunit/violation/violationlayer/P2ViolationLayer.java
@@ -1,0 +1,5 @@
+package com.devonfw.sample.archunit.violation.violationlayer;
+
+public class P2ViolationLayer {
+    // No layer should have the name violation, resulting in the error for this class.
+}


### PR DESCRIPTION
This PR introduces code with violations of the package convention rules.
You can see this new and invalid code in the `Files changed` tab and you can also see the resulting errors reported by our ArchUnit test if you click on the details of the build error (see red cross at the bottom).

This PR shall never be merged - it is only for demonstration purpose, see #8 for details